### PR TITLE
Remove actor after dying

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -133,3 +133,16 @@ class DamageJob(essentials.Job):
         )
         repeat = None if self.should_conclude() else self.REPEAT_INTERVAL
         return essentials.JobResult(events=[event], actions=[action], repeat=repeat)
+
+
+class DieJob(essentials.Job):
+    def __init__(self, dier_id: defs.ActorId) -> None:
+        super().__init__()
+        self.dier_id = dier_id
+
+    def get_start_delay(self) -> float:
+        return 0.0
+
+    def execute(self, state: state.State) -> essentials.JobResult:
+        state.delete_entity(self.dier_id)
+        return essentials.JobResult()

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -253,13 +253,11 @@ class InventoryUpdateTask(essentials.Task):
 
 
 class DieAndDropTask(essentials.Task):
-    DIE_DURATION = 0.01  # sec
-
     def __init__(self, dier_id: essentials.EntityId, drops: List[essentials.Entity]) -> None:
         super().__init__()
         self.dier_id = dier_id
         self.drops = drops
-        self.job = jobs.WaitJob(self.DIE_DURATION, [events.FinishedEvent(self.dier_id)])
+        self.job = jobs.DieJob(self.dier_id)
 
     def start(self, state: state.State) -> Sequence[actions.Action]:
         dier = state.get_entity(self.dier_id)


### PR DESCRIPTION
Entities are not removed when they die. Let's define a job removing them and use it in `DieAndDropTask` task.